### PR TITLE
Better logging and better precision for Mockery

### DIFF
--- a/validate-tests.sh
+++ b/validate-tests.sh
@@ -1,13 +1,21 @@
-set -e
-test $(git grep "test.only(" -- '*.js' | wc -l) -eq 0
-echo "test.only succeeds"
-test $(git grep "experiment.only(" -- '*.js' | wc -l) -eq 0
-echo "experiment.only succeeds"
-test $(git grep "suite.only(" -- '*.js' | wc -l) -eq 0
-echo "suite.only succeeds"
-test $(git grep "Mockery.enable(" -- '*.js' | wc -l) -eq `expr $(git grep "Mockery.disable\|Mockery.deregisterAll(" -- '*.js' | wc -l) / 2`
-echo "Mockery succeeds"
-test $(git grep "experiment.skip(" -- '*.js' | wc -l) -eq 0
-echo "experiment.skip succeeds"
-test $(git grep "suite.skip(" -- '*.js' | wc -l) -eq 0
-echo "suite.skip succeeds"
+
+echo "Checking for skipped tests..."
+TEST_CHECK=$(git grep -n '\(test\|experiment\|suite\).\(only\|skip\)' -- '*.js') RCODE=$?
+if [ $RCODE -ne 1 ]; then
+  echo "STOP: You're still skipping tests"
+  echo "$TEST_CHECK"
+  exit 1
+else
+  echo "No skipped tests!"
+fi
+
+echo "Checking for mockery enable / disable / deregisters..."
+MOCKERY_ENABLES=$(git grep "Mockery.enable(" -- '*.js' | wc -l)
+MOCKERY_DISABLED=$(git grep "Mockery.disable\|Mockery.deregisterAll(" -- '*.js' | wc -l)
+MOCKERY_ENABLES_DOUBLE=$(($MOCKERY_ENABLES * 2))
+if [ $MOCKERY_ENABLES_DOUBLE -ne $MOCKERY_DISABLED ]; then
+  echo "STOP: Mockery enables: $MOCKERY_ENABLES vs $MOCKERY_DISABLED disables / deregisterAlls (should be double)"
+  exit 1
+else
+  echo "Mockery is fine!"
+fi


### PR DESCRIPTION
Now shows what files offend (skipped tests). For mockery just a bit more logging.
Also fixed off-by-one error for Mockery disables vs enables (*2 instead of /2)